### PR TITLE
Fix running t/getopt.t from a read-only location

### DIFF
--- a/t/getopt.t
+++ b/t/getopt.t
@@ -2,6 +2,8 @@
 print "1..14\n";
 
 use Tk::Getopt;
+use File::Temp qw(tempdir);
+use File::Spec ();
 
 $bla  = 1;
 $bla2 = 1;
@@ -57,8 +59,8 @@ print "ok 4\n";
 print "not " unless "@ARGV" eq "file";
 print "ok 5\n";
 
-my $tstfile = "getopt.tst";
-unlink $tstfile;
+my $tstdir = tempdir(CLEANUP => 1);
+my $tstfile = File::Spec->catfile($tstdir, "getopt.tst");
 $opt->save_options($tstfile);
 print "not " if !-f $tstfile;
 print "ok 6\n";
@@ -93,5 +95,3 @@ print "ok 13\n";
 
 print "not " unless ($bla4 == 0);
 print "ok 14\n";
-
-unlink $tstfile;


### PR DESCRIPTION
If current working directory is a read-only location, running t/getopt.t fails:

    $ perl t/getopt.t
    1..14
    ok 1
    ok 2
    ok 3
    ok 4
    ok 5
    Writing to config file <getopt.tst> failed: Permission denied
     at t/getopt.t line 62.

This patch fixes it by using a temporary directory with File::Temp. File::Temp is smart enough to find a suitalbe writable location and clean up on exit. File::Temp is already used in other tests, e.g. in t/modern.t.